### PR TITLE
feat: latitude and longitude dd/dms

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,48 +17,53 @@ const kilometersRounded = miles.as('kilometers', 2); // 296119.3
 
 # Supported Units
 
-| Distance | aliases |
-|----------|---------|
-| inch | `in` `inch` `inches`|
-| foot | `ft` `foot` `feet` |
-| mile | `mi` `mile` `miles` |
-| meter | `m` `meter` `meters` `metre` `metres` |
-| kilometer | `km` `kilometer` `kilometers` |
+| Distance  | aliases                               |
+| --------- | ------------------------------------- |
+| inch      | `in` `inch` `inches`                  |
+| foot      | `ft` `foot` `feet`                    |
+| mile      | `mi` `mile` `miles`                   |
+| meter     | `m` `meter` `meters` `metre` `metres` |
+| kilometer | `km` `kilometer` `kilometers`         |
 
-| Pressure | aliases |
-|----------|---------|
-| pounds per square inch| `psi` `psis` |
-| pascal | `pa` `pascal` `pascals` |
-| bar | `bar` `bars` |
-| millibar | `mbar` `millibar` `mbars` `millibars` `hectopascal` `hectopascals` |
-| millimeter of mercury | `mmhg` `torr` |
-| atmospheric | `atmosphere` `atmospheres` `atmospheric` `barometric` |
-| kilopascal | `kpa` `kpas` `kilopascal` `kilopascals` |
+| Pressure               | aliases                                                            |
+| ---------------------- | ------------------------------------------------------------------ |
+| pounds per square inch | `psi` `psis`                                                       |
+| pascal                 | `pa` `pascal` `pascals`                                            |
+| bar                    | `bar` `bars`                                                       |
+| millibar               | `mbar` `millibar` `mbars` `millibars` `hectopascal` `hectopascals` |
+| millimeter of mercury  | `mmhg` `torr`                                                      |
+| atmospheric            | `atmosphere` `atmospheres` `atmospheric` `barometric`              |
+| kilopascal             | `kpa` `kpas` `kilopascal` `kilopascals`                            |
 
-| Temperature | aliases |
-| ----------- | ------- |
-| kelvin | `k` `kelvin` `kelvins` |
-| fahrenheit | `f` `fahrenheit` |
-| celsius | `c` `celsius` `centigrade` |
+| Temperature | aliases                    |
+| ----------- | -------------------------- |
+| kelvin      | `k` `kelvin` `kelvins`     |
+| fahrenheit  | `f` `fahrenheit`           |
+| celsius     | `c` `celsius` `centigrade` |
 
-| Mass | aliases |
-| ---- | ------- |
-| ounce | `oz` `ounce` `ounces` |
-| pound | `lb` `lbs` `pound` `pounds` |
-| gram | `g` `gm` `gram` `grams` |
+| Mass     | aliases                     |
+| -------- | --------------------------- |
+| ounce    | `oz` `ounce` `ounces`       |
+| pound    | `lb` `lbs` `pound` `pounds` |
+| gram     | `g` `gm` `gram` `grams`     |
 | kilogram | `kg` `kilogram` `kilograms` |
 
-| Volume | aliases |
-| ------ | ------- |
-| milliliter  | `ml` `milliliter` `milliliters` `millilitre` `millilitres`|
-| liter  | `l` `liter` `liters` `litre` `litres`|
-| us gallon | `usgal` `usgallon` `usgallons` |
-| imperial gallon | `gal` `gallon` `gallons` |
+| Volume          | aliases                                                    |
+| --------------- | ---------------------------------------------------------- |
+| milliliter      | `ml` `milliliter` `milliliters` `millilitre` `millilitres` |
+| liter           | `l` `liter` `liters` `litre` `litres`                      |
+| us gallon       | `usgal` `usgallon` `usgallons`                             |
+| imperial gallon | `gal` `gallon` `gallons`                                   |
 
-| Fuel Economy | aliases |
-| ------ | ------- |
-| kilometers per liter  | `kmpl` `km/l`|
-| us miles per gallon | `mpg` |
+| Fuel Economy         | aliases       |
+| -------------------- | ------------- |
+| kilometers per liter | `kmpl` `km/l` |
+| us miles per gallon  | `mpg`         |
+
+| Latitude/Longitude     | aliases                                    |
+| ---------------------- | ------------------------------------------ |
+| decimal degrees        | `dd` `degree` `degrees`                    |
+| degree/minutes/seconds | `dms` `degminsec`, `degreesminutesseconds` |
 
 [npm-url]: https://www.npmjs.com/package/smartcar-unit
 [npm-image]: https://img.shields.io/npm/v/smartcar-unit.svg?style=flat-square

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -169,7 +169,7 @@ test('dms - decimal is integer', function(t) {
   const [d, m, s] = dms.split(',');
   t.is(d, '90');
   t.is(m, '0');
-  t.is(s, '00.00');
+  t.is(s, '0');
 });
 
 test('dms - seconds value is 0', function(t) {
@@ -177,7 +177,7 @@ test('dms - seconds value is 0', function(t) {
   const [d, m, s] = dms.split(',');
   t.is(d, '90');
   t.is(m, '30');
-  t.is(s, '00.00');
+  t.is(s, '0');
 });
 
 

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -145,3 +145,46 @@ test('mpg', function(t) {
   const mpg = unit(0.425144, 'kmpl').as('mpg');
   t.true(approximately(mpg, 1));
 });
+
+test('decimal degrees - dms is csv', function(t) {
+  const dd = unit('90,30,30', 'dms').as('dd');
+  t.true(approximately(dd, 90.50833));
+});
+
+test('decimal degrees - dms is array', function(t) {
+  const dd = unit([90, 30, 30], 'dms').as('dd');
+  t.true(approximately(dd, 90.50833));
+});
+
+test('dms', function(t) {
+  const dms = unit(90.50833333333333, 'dd').as('dms');
+  const [d, m, s] = dms.split(',');
+  t.is(d, '90');
+  t.is(m, '30');
+  t.is(s, '30');
+});
+
+test('dms - decimal is integer', function(t) {
+  const dms = unit(90, 'dd').as('dms');
+  const [d, m, s] = dms.split(',');
+  t.is(d, '90');
+  t.is(m, '0');
+  t.is(s, '00.00');
+});
+
+test('dms - seconds value is 0', function(t) {
+  const dms = unit(90.5, 'dd').as('dms');
+  const [d, m, s] = dms.split(',');
+  t.is(d, '90');
+  t.is(m, '30');
+  t.is(s, '00.00');
+});
+
+
+test('dms - degree is negative', function(t) {
+  const dms = unit(-90.50833333333333, 'dd').as('dms');
+  const [d, m, s] = dms.split(',');
+  t.is(d, '-90');
+  t.is(m, '30');
+  t.is(s, '30');
+});

--- a/units.js
+++ b/units.js
@@ -108,4 +108,36 @@ module.exports = {
     base: 2.35215,
     aliases: [],
   },
+  dd: {
+    from: function(dms) {
+      const [deg, min, sec] = Array.isArray(dms)
+        ? dms
+        : dms.split(',').map((val) => Number(val));
+      return deg + (min / 60) + (sec / 3600);
+    },
+    to: function(dd) { return dd; },
+    aliases: ['degree', 'degrees', 'decimaldegrees'],
+  },
+  dms: {
+    from: function(dd) {
+      const degrees = Math.trunc(dd);
+      let decimal = Math.abs(dd - degrees);
+      if (decimal === 0) { return `${degrees},0,00.00`; }
+
+      const decimalMinutes = decimal * 60;
+      const minutes = Math.trunc(decimalMinutes);
+      decimal = decimalMinutes - minutes;
+      if (decimal === 0) { return `${degrees},${minutes},00.00`; }
+
+      let decimalSeconds = decimal * 60;
+      decimalSeconds = Math.round(decimalSeconds * 10000) / 10000;
+      if (decimalSeconds < 10) {
+        decimalSeconds = '0' + String(decimalSeconds);
+      }
+
+      return `${degrees},${minutes},${decimalSeconds}`;
+    },
+    to: function(dms) { return dms; },
+    aliases: ['degminsec', 'degreesminutesseconds'],
+  },
 };

--- a/units.js
+++ b/units.js
@@ -122,18 +122,15 @@ module.exports = {
     from: function(dd) {
       const degrees = Math.trunc(dd);
       let decimal = Math.abs(dd - degrees);
-      if (decimal === 0) { return `${degrees},0,00.00`; }
+      if (decimal === 0) { return `${degrees},0,0`; }
 
       const decimalMinutes = decimal * 60;
       const minutes = Math.trunc(decimalMinutes);
       decimal = decimalMinutes - minutes;
-      if (decimal === 0) { return `${degrees},${minutes},00.00`; }
+      if (decimal === 0) { return `${degrees},${minutes},0`; }
 
       let decimalSeconds = decimal * 60;
       decimalSeconds = Math.round(decimalSeconds * 10000) / 10000;
-      if (decimalSeconds < 10) {
-        decimalSeconds = '0' + String(decimalSeconds);
-      }
 
       return `${degrees},${minutes},${decimalSeconds}`;
     },


### PR DESCRIPTION
This PR adds conversions for these latitude/longitude units:
1. Decimal degrees - `dd`
2. Degrees/minutes/seconds - `dms`

### Reference Material
- https://www.youtube.com/watch?v=W9kousU6AI0
- Naming - https://en.wikipedia.org/wiki/Decimal_degrees#:~:text=Unsourced%20material%20may%20be%20challenged%20and%20removed.&text=Decimal%20degrees%20(DD)%20is%20a,as%20OpenStreetMap%2C%20and%20GPS%20devices.

### Notes
- `dms` can be passed as a comma-separated string (e.g. `'90,30,40.90'`) OR an array (`[90, 30, 40.90]`)
- `dms` is always returned as a comma-separated string
-  The `seconds` (as in minute vs seconds) value is rounded to the nearest 10000ths place

Asana: https://app.asana.com/0/1204182324137082/1204241114292178

